### PR TITLE
Fix integer TypeError in get_payment_id() function.

### DIFF
--- a/src/simplewallet_basic_rpc_call_04.py
+++ b/src/simplewallet_basic_rpc_call_04.py
@@ -144,8 +144,7 @@ def get_payment_id():
     json will not not what to do with the byte array.
     """
 
-    random_32_bytes = os.urandom(32)
-    payment_id = "".join(map(chr, binascii.hexlify(random_32_bytes)))
+    payment_id = os.urandom(32).encode('hex')
 
     return payment_id
 


### PR DESCRIPTION
When running the example, a TypeError occurs in the get_payment_id() function, line 148:
    payment_id = "".join(map(chr, binascii.hexlify(random_32_bytes)))
TypeError: an integer is required
